### PR TITLE
Fix interative node ns issue

### DIFF
--- a/fabrics_bridge/launch/fabrics_demo.launch
+++ b/fabrics_bridge/launch/fabrics_demo.launch
@@ -31,12 +31,11 @@
         <!-- start nodes -->
         <node pkg="fabrics_bridge" type="fabrics_node" name="fabrics_node" output="screen"/>
         <node pkg="fabrics_bridge" type="client_node" name="client_node" output="screen"/>
-
-        <group if="$(arg use_it_marker)">
-            <node name="interactive_marker" pkg="fabrics_bridge" type="interactive_marker.py">
-                <param name="link_name" value="panda_link0" />
-                <remap to="planning_goal" from="equilibrium_pose" />
-            </node>
-        </group>
+    </group>
+    <group if="$(arg use_it_marker)">
+        <node name="interactive_marker" pkg="fabrics_bridge" type="interactive_marker.py">
+            <param name="link_name" value="panda_link0" />
+            <remap to="/fabrics/planning_goal" from="equilibrium_pose" />
+        </node>
     </group>
 </launch>


### PR DESCRIPTION
The interactive marker didn't work because `franka_states` published by gazebo is not in `fabrics` ns so I've moved iterative_marker node outside of `fabrics` ns.

I've also prepended `/fabrics` ns to `planning_goal` for remapping.
