### PR TITLE
move the joint_state and stop_acc_bool conditions to the outer if statement

### DIFF
--- a/fabrics_bridge/scripts/fabrics_node
+++ b/fabrics_bridge/scripts/fabrics_node
@@ -57,6 +57,7 @@ class FabricsNode(object):
 
         self.state = FabricsState()
         self.state.goal_reached = False
+        self.state.positional_error = 1
         self.state.angular_error = 1
 
         self.init_markers()


### PR DESCRIPTION
While switching between goal types `ee_pose` and `joint_space`, some errors occur. 

The `joint_states` are needed in evaluate() and a correct planner (use `self.stop_acc_bool` to verify) should be at the ready before `act()` and `evaluate()`. It would make more sense that the `act()` and `evaluate()` happen only when a goal, joint_states and a correct planner are received.