### PR TITLE
Resolve dependency conflicts in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,3 @@ scipy
 # fabrics dependencies
 # install private repo using ssh credentials
 git+ssh://git@github.com/maxspahn/fabrics.git@develop
-
-# public repos
-git+https://github.com/maxspahn/forwardKinematics.git@release-1.0#egg=forwardKinematics
-git+https://github.com/maxspahn/motion_planning_scenes.git@main#egg=motion_planning_scenes


### PR DESCRIPTION
Fabrics now depends on forwardkinematics in `release-1.0` branch not main branch.