### PR TITLE
Adds tolerance to goal and state for more information and flexibility.

### DIFF
--- a/fabrics_bridge/scripts/joint_space_client_node
+++ b/fabrics_bridge/scripts/joint_space_client_node
@@ -38,6 +38,9 @@ class JointSpaceExampleClient(object):
         self._goal_publisher = rospy.Publisher(
             "fabrics/planning_goal", FabricsGoal, queue_size=10
         )
+        self._obs_publisher = rospy.Publisher(
+            "fabrics/planning_obs", FabricsObstacleArray, queue_size=10
+        )
 
     def publish_goal(self):
         goal = FabricsGoal()
@@ -47,6 +50,7 @@ class JointSpaceExampleClient(object):
         goal.goal_joint_state.position = [-1.7, -0.2, -1.4, -1.501, 0.0, 1.2675, 0.0]
         goal.goal_type = "joint_space"
         goal.weight_goal_0 = 1.0
+        goal.tolerance_goal_0 = 0.02
         self._goal_publisher.publish(goal)
 
     def run(self):

--- a/fabrics_msgs/msg/FabricsGoal.msg
+++ b/fabrics_msgs/msg/FabricsGoal.msg
@@ -3,3 +3,5 @@ sensor_msgs/JointState goal_joint_state
 string goal_type #either ee_pose or joint_space
 float32 weight_goal_0
 float32 weight_goal_1
+float32 tolerance_goal_0
+float32 tolerance_goal_1

--- a/fabrics_msgs/msg/FabricsState.msg
+++ b/fabrics_msgs/msg/FabricsState.msg
@@ -2,3 +2,5 @@ std_msgs/Header header
 bool goal_reached
 float32 positional_error
 float32 angular_error
+float32 tolerance_goal_0
+float32 tolerance_goal_1


### PR DESCRIPTION
The parameters should not statically load tolerances for goals.
Now, you can specify the tolerance in the message.
The state evaluator will also return the currently selected tolerance.