### PR TITLE
Changed goal weights and references to files that include word panda

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ roslaunch fabrics_bridge fabrics_interactive_marker.launch
 If you have a module which can publish data to `/planning_goal` and `/planning_obs`, run:
 
 ```bash
-roslaunch fabrics_bridge fabrics_node.launch
+roslaunch fabrics_bridge fabrics_panda_node.launch
 ```
 An example client node that can publish `/planning_goal` and `/planning_obs`:
 

--- a/fabrics_bridge/launch/fabrics_interactive_marker.launch
+++ b/fabrics_bridge/launch/fabrics_interactive_marker.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-    <rosparam command="load" file="$(find fabrics_bridge)/config/fabrics_config.yaml"/>
-    <include file="$(find fabrics_bridge)/launch/fabrics_node.launch" />
+    <rosparam command="load" file="$(find fabrics_bridge)/config/fabrics_panda_config.yaml"/>
+    <include file="$(find fabrics_bridge)/launch/fabrics_panda_node.launch" />
     <node name="interactive_marker" pkg="fabrics_bridge" type="interactive_marker.py">
         <param name="link_name" value="panda_link0" />
     </node>

--- a/fabrics_bridge/scripts/ee_pose_goal_panda
+++ b/fabrics_bridge/scripts/ee_pose_goal_panda
@@ -47,7 +47,7 @@ class ClientNode(object):
         # radius of shelf (suppose it's a circular shelf)
         self.r_shelf = 0.30
         # diameter of a sphere
-        self.r_obs = 0.15
+        self.r_obs = 0.05
         self.obs = FabricsObstacleArray()
 
     def init_publishers(self):
@@ -127,7 +127,7 @@ class ClientNode(object):
     def run(self):
         while not rospy.is_shutdown():
             self.publish_goal(
-                0.8, 0.2, 0.70, 0, -0.7071067811865475, 0, -0.7071067811865475, 20, 10
+                0.8, 0.2, 0.70, 0, -0.7071067811865475, 0, -0.7071067811865475, 1, 2
             )
             self.publish_obs()
             self._rate.sleep()


### PR DESCRIPTION
Changed goal weights for the end-effector goal pose to 1, 2 instead of 10, 20. 
Changed names of launch files to fabrics_panda_node.launch in "fabrics_interactive_marker.launch" and the readme, instead of fabrics_node.launch.

IMPORTANT: Bug that is remaining: interactive_marker runs but isn't interacting with the robot.
end-effector pose reaching is not good in simulation.